### PR TITLE
Reboot the system after expanding the image

### DIFF
--- a/image/appliance.kiwi
+++ b/image/appliance.kiwi
@@ -26,6 +26,7 @@
                 <oem-unattended>false</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>
                 <oem-multipath-scan>false</oem-multipath-scan>
+                <oem-reboot-interactive>true</oem-reboot-interactive>
             </oemconfig>
             <systemdisk>
                 <volume name="home"/>


### PR DESCRIPTION
Without setting "oem-reboot-interactive" or "oem-reboot", kiwi just uses
kexec to load the installed system and this may cause some problems with
TPM measurement.