### PR TITLE
oracle: read variables from efivarfs as a fallback

### DIFF
--- a/src/runtime.h
+++ b/src/runtime.h
@@ -25,6 +25,7 @@
 #include "bufparser.h"
 
 #define RUNTIME_SHORT_READ_OKAY		0x0001
+#define RUNTIME_READ_EFIVARFS		0x0002
 
 extern buffer_t *	runtime_read_file(const char *pathname, int flags);
 extern buffer_t *	runtime_read_efi_variable(const char *var_name);


### PR DESCRIPTION
Although efivar sysfs is enabled by default for the x86 systems, it may no be available in an AArch64 system. Amend __system_read_efi_variable() to read variables from efivarfs if the efivar entry doesn't exist.

Signed-off-by: Gary Lin <glin@suse.com>